### PR TITLE
Improve filename editing

### DIFF
--- a/Upupu.xcodeproj/project.pbxproj
+++ b/Upupu.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		8FBDBA3A1D76D42F004DB68A /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBDBA391D76D42F004DB68A /* Settings.swift */; };
 		8FBDBA3D1D76E158004DB68A /* UIImage+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBDBA3C1D76E158004DB68A /* UIImage+Utils.swift */; };
 		8FBDBA3F1D76EB1B004DB68A /* CameraHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBDBA3E1D76EB1B004DB68A /* CameraHelper.swift */; };
+		8FBE49E91D94F87800D42D7A /* FilenameTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBE49E81D94F87800D42D7A /* FilenameTextField.swift */; };
 		8FF66B471D800F9F0032F765 /* CameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FF66B461D800F9F0032F765 /* CameraView.swift */; };
 		8FF66B491D8014E60032F765 /* UploadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FF66B481D8014E60032F765 /* UploadView.swift */; };
 		8FF74BBE1D7424D300437DE6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FF74BBD1D7424D300437DE6 /* AppDelegate.swift */; };
@@ -73,6 +74,7 @@
 		8FBDBA391D76D42F004DB68A /* Settings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Settings.swift; path = Commons/Settings.swift; sourceTree = "<group>"; };
 		8FBDBA3C1D76E158004DB68A /* UIImage+Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIImage+Utils.swift"; path = "Commons/UIImage+Utils.swift"; sourceTree = "<group>"; };
 		8FBDBA3E1D76EB1B004DB68A /* CameraHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CameraHelper.swift; path = Commons/CameraHelper.swift; sourceTree = "<group>"; };
+		8FBE49E81D94F87800D42D7A /* FilenameTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FilenameTextField.swift; path = Views/FilenameTextField.swift; sourceTree = "<group>"; };
 		8FF66B461D800F9F0032F765 /* CameraView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CameraView.swift; path = Views/CameraView.swift; sourceTree = "<group>"; };
 		8FF66B481D8014E60032F765 /* UploadView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UploadView.swift; path = Views/UploadView.swift; sourceTree = "<group>"; };
 		8FF74BBD1D7424D300437DE6 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -182,6 +184,7 @@
 			children = (
 				8F0ADA151D76964A00C58D0B /* BlackToolBar.swift */,
 				8FF66B461D800F9F0032F765 /* CameraView.swift */,
+				8FBE49E81D94F87800D42D7A /* FilenameTextField.swift */,
 				8FF66B481D8014E60032F765 /* UploadView.swift */,
 			);
 			name = Views;
@@ -384,6 +387,7 @@
 				8FFD7F881D744E9700517B38 /* UploadViewController.swift in Sources */,
 				8F0ADA161D76964A00C58D0B /* BlackToolBar.swift in Sources */,
 				8FBDBA3D1D76E158004DB68A /* UIImage+Utils.swift in Sources */,
+				8FBE49E91D94F87800D42D7A /* FilenameTextField.swift in Sources */,
 				8FA55E101D75528600ECB21E /* DropboxUploader.swift in Sources */,
 				8FF74BBE1D7424D300437DE6 /* AppDelegate.swift in Sources */,
 				8FFE1B2A1D743A8E00CCEE67 /* RootViewController.swift in Sources */,

--- a/Upupu/Controllers/UploadViewController.swift
+++ b/Upupu/Controllers/UploadViewController.swift
@@ -63,10 +63,10 @@ class UploadViewController: UIViewController, MBProgressHUDDelegate, UITextField
 
         if let text = uploadView.nameTextField.text {
             if text.isEmpty {
-                uploadView.nameTextField.text = makeFilename()
+                uploadView.nameTextField.fileStem = makeFilename()
             }
         } else {
-            uploadView.nameTextField.text = makeFilename()
+            uploadView.nameTextField.fileStem = makeFilename()
         }
 
         super.viewWillAppear(animated)
@@ -201,7 +201,7 @@ class UploadViewController: UIViewController, MBProgressHUDDelegate, UITextField
 
         // Upload to ...
         if let imageData = imageData(image) {
-            let fileStem = uploadView.nameTextField.text
+            let fileStem = uploadView.nameTextField.fileStem
             let filename: String
             if fileStem == nil || fileStem!.isEmpty {
                 filename = "\(Uploader.fileStem()).jpg"
@@ -229,7 +229,17 @@ class UploadViewController: UIViewController, MBProgressHUDDelegate, UITextField
 
     // MARK: - TextFieldDelegate
 
+    func textFieldShouldBeginEditing(textField: UITextField) -> Bool {
+        if let filenameTextField = textField as? FilenameTextField {
+            filenameTextField.extentionHidden = true
+        }
+        return true
+    }
+
     func textFieldShouldReturn(textField: UITextField) -> Bool {
+        if let filenameTextField = textField as? FilenameTextField {
+            filenameTextField.extentionHidden = false
+        }
         textField.resignFirstResponder()
         return true
     }

--- a/Upupu/Views/FilenameTextField.swift
+++ b/Upupu/Views/FilenameTextField.swift
@@ -1,0 +1,75 @@
+//
+//  FilenameTextField.swift
+//  Upupu
+//
+//  Created by Toshiki Takeuchi on 9/23/16.
+//  Copyright © 2016 Xcoo, Inc. All rights reserved.
+//  See LISENCE for Upupu's licensing information.
+//
+
+import UIKit
+
+class FilenameTextField: UITextField {
+
+    var fileStem: String? {
+        get {
+            if let fileExtension = fileExtension {
+                return text?.stringByReplacingOccurrencesOfString("(.*)\\\(fileExtension)$",
+                                                                  withString: "$1",
+                                                                  options: .RegularExpressionSearch,
+                                                                  range: nil)
+            } else {
+                return text
+            }
+        }
+
+        set(fileStem) {
+            text = fileStem
+            formatFilename()
+        }
+    }
+
+    var fileExtension: String? {
+        didSet { formatFilename() }
+    }
+
+    var extentionHidden = false {
+        didSet { formatFilename() }
+    }
+
+    private let fileStemAttributes = [NSForegroundColorAttributeName: UIColor.blackColor()]
+    private let fileExtensionAttributes = [NSForegroundColorAttributeName: UIColor.grayColor()]
+
+    init(fileExtension: String?) {
+        super.init(frame: CGRect.zero)
+        self.fileExtension = fileExtension
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func formatFilename() {
+        guard let stem = fileStem where !stem.isEmpty else {
+            return
+        }
+
+        guard let extension_ = fileExtension where !extension_.isEmpty else {
+            return
+        }
+
+        if extentionHidden {
+            attributedText = NSAttributedString(string: stem, attributes: fileStemAttributes)
+        } else {
+            if let text = text where !text.isEmpty {
+                let mainStr = NSMutableAttributedString(string: text,
+                                                        attributes: fileStemAttributes)
+                let extensionStr = NSAttributedString(string: extension_,
+                                                      attributes: fileExtensionAttributes)
+                mainStr.appendAttributedString(extensionStr)
+                attributedText = mainStr
+            }
+        }
+    }
+
+}

--- a/Upupu/Views/UploadView.swift
+++ b/Upupu/Views/UploadView.swift
@@ -16,12 +16,13 @@ class UploadView: UIView {
     private let topToolbar = BlackToolBar(bottomBorderEnabled: true)
     private let bottomToolbar = BlackToolBar(topBorderEnabled: true)
 
-    let nameTextField: UITextField = {
-        let textField = UITextField()
+    let nameTextField: FilenameTextField = {
+        let textField = FilenameTextField(fileExtension: ".jpg")
         textField.borderStyle = .RoundedRect
         textField.textAlignment = .Center
         textField.font = UIFont.systemFontOfSize(13)
         textField.placeholder = "Input name"
+        textField.clearButtonMode = .WhileEditing
         return textField
     }()
 

--- a/Upupu/Views/UploadView.swift
+++ b/Upupu/Views/UploadView.swift
@@ -23,6 +23,8 @@ class UploadView: UIView {
         textField.font = UIFont.systemFontOfSize(13)
         textField.placeholder = "Input name"
         textField.clearButtonMode = .WhileEditing
+        textField.returnKeyType = .Done
+        textField.keyboardType = .ASCIICapable
         return textField
     }()
 


### PR DESCRIPTION
This PR improves UITextField of filename in upload view.

* Show a file extension (e.g. `.jpg`) in the filename field.
* Make keyboard return type to `Done`
* Make keyboard type ASCII